### PR TITLE
Run Dependabot more regularly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"


### PR DESCRIPTION
This makes it less likely that multiple PRs with dependency updates are opened on the same day which conflict with one another and need rebasing.