### PR TITLE
Update Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,12 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [tool.poe.tasks]
-_ruff_fix = "ruff --fix ."
+_ruff_check_fix = "ruff check --fix ."
 _ruff_fmt = "ruff format ."
-fmt = ["_ruff_fix", "_ruff_fmt"]
+fmt = ["_ruff_check_fix", "_ruff_fmt"]
 
 _ruff_fmt_check = "ruff format --check ."
-_ruff_check = "ruff ."
+_ruff_check = "ruff check ."
 _mypy = "mypy ."
 lint = ["_ruff_fmt_check", "_ruff_check", "_mypy"]
 
@@ -63,11 +63,13 @@ addopts = "--cov=xdg_base_dirs --cov-report=term-missing"
 
 [tool.ruff]
 target-version = "py310"
-select = ["ALL"]
-ignore = ["COM812", "D203", "D213", "INP001", "ISC001", "S101"]
 
 [tool.ruff.format]
 skip-magic-trailing-comma = true
 
-[tool.ruff.isort]
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = ["COM812", "D203", "D213", "INP001", "ISC001", "S101"]
+
+[tool.ruff.lint.isort]
 split-on-trailing-comma = false


### PR DESCRIPTION
The top-level linter settings are deprecated in favour of their counterparts in the `lint` section, and `ruff <path>` is deprecated for `ruff check <path>`.